### PR TITLE
Production dependencies

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,15 +1,14 @@
 const path = require('path');
 const express = require('express');
-const webpack = require('webpack');
-const webpackMiddleware = require('webpack-dev-middleware');
-const webpackHotMiddleware = require('webpack-hot-middleware');
-const config = require('./../webpack.config.js');
-
 const isDeveloping = process.env.NODE_ENV !== 'production';
 const port = isDeveloping ? 3000 : process.env.PORT;
 const app = express();
 
 if (isDeveloping) {
+    const webpack = require('webpack');
+    const webpackMiddleware = require('webpack-dev-middleware');
+    const webpackHotMiddleware = require('webpack-hot-middleware');
+    const config = require('./../webpack.config.js');
     const compiler = webpack(config);
     const middleware = webpackMiddleware(compiler, {
         publicPath: config.output.publicPath,
@@ -31,9 +30,9 @@ if (isDeveloping) {
         res.end();
     });
 } else {
-    app.use(express.static(__dirname + './frontend/dist'));
+    app.use(express.static(path.join(__dirname, '..', 'frontend', 'dist')));
     app.get('*', function response(req, res) {
-        res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+        res.sendFile(path.join(__dirname, '..', 'frontend', 'dist', 'index.html'));
     });
 }
 


### PR DESCRIPTION
Webpack is included only in `devDependencies,` therefore it won't be possible to launch this app in production mode because of missing dependencies.

Also, path to the `bundle.js` is now corrected.